### PR TITLE
JSON.pretty_print errors with Rails 3

### DIFF
--- a/brunch.gemspec
+++ b/brunch.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rake', '>= 0.8.7')
   s.add_dependency('erubis', '>= 2.6.6')
   s.add_dependency('map', '>= 3.0.0')
+  s.add_dependency('yajl-ruby', '>= 0.8.2')
 
   s.add_development_dependency('rspec', ">=2.5.0")
   s.add_development_dependency('rr', ">=1.0.2")

--- a/lib/brunch.rb
+++ b/lib/brunch.rb
@@ -1,3 +1,4 @@
+require 'yajl/json_gem'
 require File.expand_path('../brunch/cook', __FILE__)
 require File.expand_path('../brunch/seasoning', __FILE__)
 require File.expand_path('../brunch/spatula', __FILE__)

--- a/lib/brunch/cook.rb
+++ b/lib/brunch/cook.rb
@@ -117,7 +117,7 @@ class Cook
 
     puts server.inspect if $DEBUG
 
-    puts "New server running at #{server.dns_name}"
+    puts "New server running at #{server.dns_name} with id: #{server.id}"
   end
 
 end


### PR DESCRIPTION
I'm seeing this when I try to run brunch in my Rails environment:

```
Exception `NoMethodError' at /Users/paydro/.rvm/gems/ree-1.8.7-2010.02@twylah_front/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:61 - undefined method `merge' for #<JSON::Ext::Generator::State:0x106135658>
rake aborted!
undefined method `merge' for #<JSON::Ext::Generator::State:0x106135658>
[path_to_gems]/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:61:in `options_for'
[path_to_gems]/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:46:in `encode'
[path_to_gems]/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:77:in `check_for_circular_references'
[path_to_gems]/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:45:in `encode'
[path_to_gems]/gems/activesupport-3.0.7/lib/active_support/json/encoding.rb:30:in `encode'
[path_to_gems]/gems/activesupport-3.0.7/lib/active_support/core_ext/object/to_json.rb:15:in `to_json'
[path_to_gems]/gems/json_pure-1.5.1/lib/json/common.rb:266:in `generate'
[path_to_gems]/gems/json_pure-1.5.1/lib/json/common.rb:266:in `pretty_generate'
```

It looks like it's using json_pure gem. I have a patch that will have Brunch use yajl-ruby for JSON functions.
